### PR TITLE
Suppress mkdir error message if dir already exists

### DIFF
--- a/build/buildlinuxarm64.sh
+++ b/build/buildlinuxarm64.sh
@@ -1,4 +1,4 @@
 dotnet publish ../omtplayer.sln -r linux-arm64 -c Release
-mkdir arm64
+[ -d arm64 ] || mkdir arm64
 cp ../bin/Release/net8.0/linux-arm64/native/omtplayer ./arm64/omtplayer
 cp ../../libvmx/build/libvmx.so ./arm64/libvmx.so


### PR DESCRIPTION
With this patch, I propose to suppress the mkdir error when the directory already exists.