### PR TITLE
Update implementation to send alsa audio

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -237,16 +237,7 @@ namespace omtplayer
                                         if (player != null) player.Dispose();
                                         player = new ALSAPlayer(AUDIO_DEVICE_PATH, (uint)frame.SampleRate, (uint)frame.Channels);
                                     }
-                                    //This is the simplest way to manage audio drift/sync, by skipping audio if it is likely this function will block due to a full device buffer.
-                                    //This should in theory limit the latency to a max of LATENCY_US (60ms)
-                                    int available = player.GetBufferAvailable();
-                                    if (available >= frame.SamplesPerChannel)
-                                    {
-                                        player.WritePlanar(frame.Data, (uint)frame.SamplesPerChannel);
-                                    } else
-                                    {
-                                        WriteLog("Audio.Skip: " + frame.SamplesPerChannel + "|" + available);
-                                    }
+                                    player.WritePlanar(frame.Data, (uint)frame.SamplesPerChannel);
                                 }
                             }
                             if (player != null)

--- a/audio/ALSAPlayer.cs
+++ b/audio/ALSAPlayer.cs
@@ -16,6 +16,12 @@ internal class ALSAPlayer : IDisposable
     private float[] srcSamples = { };
     private float[] dstSamples = { };
 
+    private enum _snd_pcm_stream_t
+    {
+        SND_PCM_STREAM_PLAYBACK = 0,
+        SND_PCM_STREAM_CAPTURE,
+    }
+
     private enum _snd_pcm_format_t
     {
         SND_PCM_FORMAT_UNKNOWN = -1,
@@ -37,6 +43,8 @@ internal class ALSAPlayer : IDisposable
         SND_PCM_FORMAT_FLOAT_BE,
     }
 
+    private const uint SND_PCM_NONBLOCK = 0x0001;
+
     private enum _snd_pcm_access_t
     {
         SND_PCM_ACCESS_MMAP_INTERLEAVED = 0,
@@ -48,7 +56,7 @@ internal class ALSAPlayer : IDisposable
     }
 
     [DllImport(Lib, CharSet = CharSet.Ansi)]
-    private static extern int snd_pcm_open(ref IntPtr pcm, string name, int stream, int mode);
+    private static extern int snd_pcm_open(ref IntPtr pcm, string name, _snd_pcm_stream_t stream, int mode);
 
     [DllImport(Lib)]
     private static extern int snd_pcm_close(IntPtr pcm);
@@ -66,6 +74,9 @@ internal class ALSAPlayer : IDisposable
     private static extern int snd_pcm_writei(IntPtr pcm, [MarshalAs(UnmanagedType.LPArray)] float[] buffer, uint size);
 
     [DllImport(Lib)]
+    private static extern int snd_pcm_recover(IntPtr pcm, int err, int silent);
+
+    [DllImport(Lib)]
     private static extern int snd_pcm_prepare(IntPtr pcm);
 
     [DllImport(Lib)]
@@ -78,7 +89,7 @@ internal class ALSAPlayer : IDisposable
     {
         this.channels = channels;
         this.sampleRate = sampleRate;
-        int hr = snd_pcm_open(ref pcmHandle, deviceName, 0, 0);
+        int hr = snd_pcm_open(ref pcmHandle, deviceName, _snd_pcm_stream_t.SND_PCM_STREAM_PLAYBACK, 0);
         if (hr != 0)
         {
             throw new Exception("Unable to open audio device " + deviceName + ": " + hr);
@@ -109,18 +120,42 @@ internal class ALSAPlayer : IDisposable
     {
         StartStream();
         int frames = snd_pcm_writei(pcmHandle, buffer, samplesPerChannel);
+        if (frames < 0)
+        {
+            int err = snd_pcm_recover(pcmHandle, frames, 1);
+            if (err < 0)
+            {
+                throw new Exception("Unable to revover sound device.");
+            }
+        }
         return frames;
     }
     public int WriteInterleaved(byte[] buffer, uint samplesPerChannel)
     {
         StartStream();
         int frames = snd_pcm_writei(pcmHandle, buffer, samplesPerChannel);
+        if (frames < 0)
+        {
+            int err = snd_pcm_recover(pcmHandle, frames, 1);
+            if (err < 0)
+            {
+                throw new Exception("Unable to revover sound device.");
+            }
+        }
         return frames;
     }
     public int WriteInterleaved(float[] buffer, uint samplesPerChannel)
     {
         StartStream();
         int frames = snd_pcm_writei(pcmHandle, buffer, samplesPerChannel);
+        if (frames < 0)
+        {
+            int err = snd_pcm_recover(pcmHandle, frames, 1);
+            if (err < 0)
+            {
+                throw new Exception("Unable to revover sound device.");
+            }
+        }
         return frames;
     }
 


### PR DESCRIPTION
- Do not call snd_pcm_avail_update. It always returns negative values due to the correctly set blocking mode opening of the PCM device
- Do not handle an audio buffer overflow in Program.cs Only one audio stream is sent and digested by the soundcard.
- Instead, handle queue return values and call the snd_pcm_recover() method in case the buffer does not accept frames. That also fixes the loss of audio when the soundcard is set in standby mode when the stream does not contain audio frames for a while, e.g. by switching sound output apps on the sender side (tested with Vmix Desktop capture and a video app changing TV channels, which works now after the change and lead to loss of audio before).

Background information:
- [snd_pcm_recover](https://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html#ga2157aaeb6fc14da3f040d76591f9d3b1) when snd_pcm_writei returns -ESTRPIPE due to being suspended
- [snd_pcm_writei](https://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html#gabc748a500743713eafa960c7d104ca6f)

When to call snd_pcm_avail: In Non-Blocking Mode: If you opened the device with SND_PCM_NONBLOCK, you should call snd_pcm_avail() or snd_pcm_avail_update() to check how many frames you can safely write without getting an -EAGAIN error.
In the case of omtplayer, I think it might be reasonable to use the blocking mode as we play only one stream to one audio device (and could open another audio device for another stream).

When NOT to call snd_pcm_avail: Blocking Mode: If you are using standard blocking mode, you do not need to check availability. Simply call snd_pcm_writei(). If the buffer is full, it will sleep until space is available.

Error Handling: Always check if snd_pcm_writei() returns a negative value (e.g., -EPIPE for underruns, -EAGAIN for full buffers), and use [snd_pcm_recover()](https://alsa-project.org) to handle them. [ALSA PCM (digital audio) interface](https://www.alsa-project.org/alsa-doc/alsa-lib/pcm.html)

[ALSA Programming Howto](https://alsamodular.sourceforge.net/alsa_programming_howto.html)